### PR TITLE
Migrate to centralized GitHub Actions workflows

### DIFF
--- a/.github/workflows/docs-only.yml
+++ b/.github/workflows/docs-only.yml
@@ -1,0 +1,43 @@
+# Example workflow for documentation-only deployment
+# Copy this file to your repository's .github/workflows/ directory
+# This is useful when you want to rebuild docs without running full CI
+
+name: Documentation Deployment Only
+
+on:
+  # Manual trigger for documentation deployment
+  workflow_dispatch:
+    inputs:
+      python-version:
+        description: 'Python version for building'
+        required: false
+        default: '3.11'
+        type: choice
+        options:
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+      post-processing-script:
+        description: 'Optional post-processing script path'
+        required: false
+        type: string
+        default: ''
+
+  # Trigger on documentation-related file changes
+  push:
+    branches: [ main ]
+    paths:
+      - '_config.yml'
+      - '_toc.yml'
+      - 'notebooks/**/*.md'
+      - 'scripts/**'
+
+jobs:
+  deploy-documentation:
+    uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_html_builder.yml@main
+    with:
+      python-version: ${{ github.event.inputs.python-version || '3.11' }}
+      post-run-script: ${{ github.event.inputs.post-processing-script || 'scripts/jdaviz_image_replacement.sh' }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notebook-ci-main.yml
+++ b/.github/workflows/notebook-ci-main.yml
@@ -1,0 +1,36 @@
+# Example workflow for running full notebook CI on main branch pushes
+# Copy this file to your repository's .github/workflows/ directory
+
+name: Notebook CI - Main Branch
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'notebooks/**'
+      - '*.yml'
+      - '*.yaml'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+
+jobs:
+  full-ci-pipeline:
+    uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_pipeline.yml@main
+    with:
+      python-version: "3.11"
+      execution-mode: "full"
+      build-html: true
+      security-scan: true
+    secrets:
+      CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
+      CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+
+  build-and-deploy-docs:
+    needs: full-ci-pipeline
+    if: success()
+    uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_html_builder.yml@main
+    with:
+      python-version: "3.11"
+      post-run-script: "scripts/jdaviz_image_replacement.sh"  # Optional
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notebook-ci-on-demand.yml
+++ b/.github/workflows/notebook-ci-on-demand.yml
@@ -1,0 +1,63 @@
+# Example workflow for on-demand notebook testing
+# Copy this file to your repository's .github/workflows/ directory
+
+name: Notebook CI - On Demand
+
+on:
+  workflow_dispatch:
+    inputs:
+      python-version:
+        description: 'Python version to use'
+        required: false
+        default: '3.11'
+        type: choice
+        options:
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+      execution-mode:
+        description: 'Execution mode'
+        required: true
+        default: 'full'
+        type: choice
+        options:
+          - 'validation-only'
+          - 'full'
+          - 'quick'
+      single-notebook:
+        description: 'Path to single notebook (optional)'
+        required: false
+        type: string
+      run-security-scan:
+        description: 'Run security scan'
+        required: false
+        default: true
+        type: boolean
+      build-documentation:
+        description: 'Build HTML documentation'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  on-demand-ci:
+    uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_pipeline.yml@main
+    with:
+      python-version: ${{ inputs.python-version }}
+      execution-mode: ${{ inputs.execution-mode }}
+      single-filename: ${{ inputs.single-notebook }}
+      build-html: ${{ inputs.build-documentation }}
+      security-scan: ${{ inputs.run-security-scan }}
+    secrets:
+      CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
+      CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+
+  build-docs-on-demand:
+    if: inputs.build-documentation == true
+    uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_html_builder.yml@main
+    with:
+      python-version: ${{ inputs.python-version }}
+      post-run-script: "scripts/jdaviz_image_replacement.sh"  # Optional
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notebook-ci-pr.yml
+++ b/.github/workflows/notebook-ci-pr.yml
@@ -1,0 +1,34 @@
+# Example workflow for running notebook CI on pull requests
+# Copy this file to your repository's .github/workflows/ directory
+
+name: Notebook CI - Pull Request
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'notebooks/**'
+      - '*.yml'
+      - '*.yaml'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+
+jobs:
+  validate-notebooks:
+    uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_pipeline.yml@main
+    with:
+      python-version: "3.11"
+      execution-mode: "validation-only"
+      build-html: false
+      security-scan: true
+    secrets:
+      CASJOBS_USERID: ${{ secrets.CASJOBS_USERID }}
+      CASJOBS_PW: ${{ secrets.CASJOBS_PW }}
+
+  build-docs-preview:
+    uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_html_builder.yml@main
+    with:
+      python-version: "3.11"
+      post-run-script: "scripts/jdaviz_image_replacement.sh"  # Optional
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/migrate-repository.sh
+++ b/migrate-repository.sh
@@ -8,7 +8,7 @@ set -e
 REPO_NAME="$1"
 ORG_NAME="${2:-spacetelescope}"
 ACTIONS_REPO="notebook-ci-actions"
-BRANCH_NAME="migrate-to-centralized-actions"
+BRANCH_NAME="migrate"
 
 # Color codes for output
 RED='\033[0;31m'

--- a/migration-status.md
+++ b/migration-status.md
@@ -1,0 +1,37 @@
+# Migration Status for notebook-ci-testing
+
+## Migration Details
+- **Repository**: spacetelescope/notebook-ci-testing
+- **Migration Date**: Mon Jun 23 14:48:10 EDT 2025
+- **Actions Repository**: spacetelescope/notebook-ci-actions
+- **Branch**: migrate
+
+## Pre-Migration Workflows
+
+
+## New Workflows
+- .github/workflows/docs-only.yml
+- .github/workflows/notebook-ci-main.yml
+- .github/workflows/notebook-ci-on-demand.yml
+- .github/workflows/notebook-ci-pr.yml
+
+## Configuration Applied
+- Default configuration
+
+## Testing Checklist
+- [ ] Manual workflow dispatch test
+- [ ] Pull request workflow test  
+- [ ] Documentation build test
+- [ ] Repository-specific features test
+
+## Migration Notes
+- Created by migration script on Mon Jun 23 14:48:10 EDT 2025
+- Review and customize workflows as needed
+- Test thoroughly before merging to main
+
+## Next Steps
+1. Review generated workflows
+2. Test with workflow_dispatch
+3. Create test PR to verify triggers
+4. Update repository secrets if needed
+5. Merge after successful testing


### PR DESCRIPTION
- Backup existing workflows to .github/workflows-backup/
- Add centralized workflows from spacetelescope/notebook-ci-actions
- Configure repository-specific parameters
- Add migration tracking file

Repository: notebook-ci-testing
Configuration: default
Migration date: Mon Jun 23 14:48:10 EDT 2025