### PR TITLE
Automate RRN delivery from notebook releases

### DIFF
--- a/.github/scripts/classify_rrn_delivery.sh
+++ b/.github/scripts/classify_rrn_delivery.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+base_ref=${1:?base ref is required}
+head_ref=${2:?head ref is required}
+
+delivery_mode=spec
+reason="Only notebook content or documentation changed"
+
+while IFS= read -r file; do
+    case "$file" in
+        *.ipynb|*.md|*.rst|*.png|*.jpg|*.jpeg|*.gif|*.svg|CITATION.cff|_toc.yml|_config.yml)
+            ;;
+        *)
+            delivery_mode=image
+            reason="Image-affecting or unclassified file changed: $file"
+            break
+            ;;
+    esac
+done < <(git diff --name-only "$base_ref" "$head_ref")
+
+printf 'delivery_mode=%s\n' "$delivery_mode"
+printf 'reason=%s\n' "$reason"

--- a/.github/scripts/dispatch_rrn_build.sh
+++ b/.github/scripts/dispatch_rrn_build.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${RRN_SOURCE_REPOSITORY:?RRN_SOURCE_REPOSITORY is required}"
+: "${RRN_SOURCE_REF:?RRN_SOURCE_REF is required}"
+: "${RRN_SOURCE_VERSION:?RRN_SOURCE_VERSION is required}"
+: "${RRN_VERSION_KIND:?RRN_VERSION_KIND is required}"
+: "${RRN_TARGET_ENVIRONMENT:?RRN_TARGET_ENVIRONMENT is required}"
+: "${RRN_DELIVERY_MODE:?RRN_DELIVERY_MODE is required}"
+: "${RRN_SOURCE_SHA:?RRN_SOURCE_SHA is required}"
+: "${RRN_RELEASE_URL:?RRN_RELEASE_URL is required}"
+: "${RRN_CORRELATION_ID:?RRN_CORRELATION_ID is required}"
+
+spi_repository=${SPI_REPOSITORY:-spacetelescope/science-platform-images}
+spi_workflow=${SPI_WORKFLOW:-build-roman-research-nexus.yml}
+
+gh workflow run "$spi_workflow" \
+    --repo "$spi_repository" \
+    --ref main \
+    -f source_repository="$RRN_SOURCE_REPOSITORY" \
+    -f roman_notebooks_ref="$RRN_SOURCE_REF" \
+    -f roman_notebooks_version="$RRN_SOURCE_VERSION" \
+    -f roman_notebooks_version_kind="$RRN_VERSION_KIND" \
+    -f target_environment="$RRN_TARGET_ENVIRONMENT" \
+    -f roman_notebooks_delivery_mode_recommendation="$RRN_DELIVERY_MODE" \
+    -f roman_notebooks_sha="$RRN_SOURCE_SHA" \
+    -f roman_notebooks_release_url="$RRN_RELEASE_URL" \
+    -f correlation_id="$RRN_CORRELATION_ID"
+
+run_id=""
+for _ in {1..60}; do
+    run_id=$(
+        gh run list \
+            --repo "$spi_repository" \
+            --workflow "$spi_workflow" \
+            --event workflow_dispatch \
+            --limit 50 \
+            --json databaseId,displayTitle \
+            --jq ".[] | select(.displayTitle | contains(\"[$RRN_CORRELATION_ID]\")) | .databaseId" \
+            | head -n1
+    )
+    if [[ -n "$run_id" ]]; then
+        break
+    fi
+    sleep 10
+done
+
+if [[ -z "$run_id" ]]; then
+    echo "Could not locate the dispatched SPI workflow run." >&2
+    exit 1
+fi
+
+run_url="https://github.com/${spi_repository}/actions/runs/${run_id}"
+echo "SPI workflow run: $run_url"
+echo "rrn_run_url=$run_url" >> "$GITHUB_OUTPUT"
+
+gh run watch "$run_id" --repo "$spi_repository" --exit-status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,44 +1,31 @@
 name: Cut release
-
-# Manual release. Product owners pick "major" or "minor" from a dropdown.
-#
-# Bumps the internal SemVer accordingly, pushes both a SemVer tag
-# (canonical, for CI) and a CalVer tag (product-facing), then creates
-# a GitHub Release titled with the CalVer and auto-generated notes.
-#
-# SemVer is monotonic and never resets:
-#
-#   minor: v1.2.0 -> v1.3.0
-#   major: v1.2.0 -> v2.0.0
-#
-# CalVer uses YEAR.MAJOR.MINOR and resets each calendar year:
-#
-#   minor: 2026.1.0 -> 2026.1.1
-#   major: 2026.1.7 -> 2026.2.0
-#
-# The first release of a new calendar year is always YEAR.1.0.
-#
-# The SemVer and CalVer numbers diverge over time by design.
-# Both tags point to the same release commit.
+run-name: Cut ${{ inputs.release_type }} CalVer for ${{ inputs.target_environment }}
 
 on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: "Which part of the version to bump"
+        description: Which part of the version to bump
         type: choice
         required: true
         default: minor
         options:
           - minor
           - major
+      target_environment:
+        description: RRN deployment target
+        type: choice
+        required: true
+        default: test
+        options:
+          - test
+          - ops
 
 permissions:
   contents: write
-  id-token: write
 
 env:
-  RELEASE_DISPLAY_NAME: "Notebook CI Testing"
+  RELEASE_DISPLAY_NAME: Notebook CI Testing
 
 concurrency:
   group: version-tagging
@@ -47,340 +34,226 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-
+    outputs:
+      calver: ${{ steps.version.outputs.calver }}
+      semver: ${{ steps.version.outputs.semver }}
+      source_sha: ${{ steps.publish.outputs.source_sha }}
+      release_url: ${{ steps.metadata.outputs.release_url }}
     steps:
-      - name: Checkout
+      - name: Checkout main
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Compute next version
-        id: ver
-        shell: bash
+      - name: Validate release authority
         env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
+          TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+        shell: bash
         run: |
           set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "CalVer releases must run from main, not $GITHUB_REF." >&2
+            exit 1
+          fi
+          git fetch origin main --tags
+          [[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]]
+          if [[ "$TARGET_ENVIRONMENT" == "ops" \
+                && "$GITHUB_REPOSITORY" != "spacetelescope/roman_notebooks" ]]; then
+            echo "Only spacetelescope/roman_notebooks may deploy to RRN ops." >&2
+            exit 1
+          fi
 
-          echo "Selected release type: '$RELEASE_TYPE'"
-          echo "Workflow ref:          '$GITHUB_REF'"
-          echo "Workflow SHA:          '$GITHUB_SHA'"
+      - name: Compute or recover release versions
+        id: version
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          exact_semver=$(git tag --points-at HEAD \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)
+          exact_calver=$(git tag --points-at HEAD \
+            | grep -E '^[0-9]{4}\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)
 
-          case "$RELEASE_TYPE" in
-            major|minor)
-              ;;
-            *)
-              echo "::error::Unknown release type: '$RELEASE_TYPE'"
+          if [[ -n "$exact_semver" || -n "$exact_calver" ]]; then
+            if [[ -z "$exact_semver" || -z "$exact_calver" ]]; then
+              echo "The current commit has only one release tag; manual recovery is required." >&2
               exit 1
-              ;;
-          esac
-
-          # Ensure all remote tags are available before calculating versions.
-          git fetch origin --force --tags
-
-          echo ""
-          echo "Existing SemVer tags:"
-          git tag --list 'v*' | sort -V || true
-
-          echo ""
-          echo "Existing CalVer tags:"
-          git tag --list '[0-9]*' | sort -V || true
-
-          # ------------------------------------------------------------
-          # SemVer: canonical, monotonic, never resets
-          #
-          # minor: v1.2.0 -> v1.3.0
-          # major: v1.2.0 -> v2.0.0
-          # ------------------------------------------------------------
-
-          latest_semver="$(
-            git tag --list 'v*.*.*' \
-              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-              | sort -V \
-              | tail -n1 \
-              || true
-          )"
-
-          if [ -z "$latest_semver" ]; then
-            latest_semver="v0.0.0"
-          fi
-
-          semver_core="${latest_semver#v}"
-          IFS='.' read -r s_major s_minor s_patch <<< "$semver_core"
-
-          case "$RELEASE_TYPE" in
-            major)
-              s_major=$((s_major + 1))
-              s_minor=0
-              s_patch=0
-              ;;
-            minor)
-              s_minor=$((s_minor + 1))
-              s_patch=0
-              ;;
-          esac
-
-          semver="v${s_major}.${s_minor}.${s_patch}"
-
-          # ------------------------------------------------------------
-          # CalVer: YEAR.MAJOR.MINOR
-          #
-          # minor: 2026.1.0 -> 2026.1.1
-          # major: 2026.1.7 -> 2026.2.0
-          #
-          # The first release of a new year is always YEAR.1.0.
-          # ------------------------------------------------------------
-
-          year="$(date -u +%Y)"
-
-          latest_calver="$(
-            git tag --list "${year}.*.*" \
-              | grep -E "^${year}\.[0-9]+\.[0-9]+$" \
-              | sort -V \
-              | tail -n1 \
-              || true
-          )"
-
-          if [ -z "$latest_calver" ]; then
-            echo ""
-            echo "No existing CalVer tag found for ${year}."
-            echo "Initializing the new year at ${year}.1.0."
-
-            c_major=1
-            c_minor=0
+            fi
+            semver=$exact_semver
+            calver=$exact_calver
+            reuse=true
           else
-            IFS='.' read -r tag_year old_c_major old_c_minor \
-              <<< "$latest_calver"
-
-            c_major="$old_c_major"
-            c_minor="$old_c_minor"
-
+            latest_semver=$(git tag -l 'v*.*.*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)
+            latest_semver=${latest_semver:-v0.0.0}
+            IFS=. read -r s_major s_minor s_patch <<< "${latest_semver#v}"
             case "$RELEASE_TYPE" in
-              major)
-                c_major=$((c_major + 1))
-                c_minor=0
-                ;;
-              minor)
-                c_minor=$((c_minor + 1))
-                ;;
+              major) s_major=$((s_major + 1)); s_minor=0; s_patch=0 ;;
+              minor) s_minor=$((s_minor + 1)); s_patch=0 ;;
+              *) echo "Unsupported release type: $RELEASE_TYPE" >&2; exit 1 ;;
             esac
+            semver="v${s_major}.${s_minor}.${s_patch}"
 
-            # Guard against a minor release accidentally changing
-            # the CalVer major component.
-            if [ "$RELEASE_TYPE" = "minor" ]; then
-              expected_major="$old_c_major"
-              expected_minor=$((old_c_minor + 1))
-
-              if [ "$c_major" -ne "$expected_major" ]; then
-                echo "::error::A minor release unexpectedly changed the CalVer major component."
-                echo "::error::Previous: $latest_calver"
-                echo "::error::Computed: ${year}.${c_major}.${c_minor}"
-                exit 1
-              fi
-
-              if [ "$c_minor" -ne "$expected_minor" ]; then
-                echo "::error::A minor release did not increment the CalVer minor component correctly."
-                echo "::error::Expected: ${year}.${expected_major}.${expected_minor}"
-                echo "::error::Computed: ${year}.${c_major}.${c_minor}"
-                exit 1
-              fi
+            year=$(date -u +%Y)
+            latest_calver=$(git tag -l "${year}.*.*" \
+              | grep -E "^${year}\.[0-9]+\.[0-9]+$" | sort -V | tail -n1 || true)
+            if [[ -z "$latest_calver" ]]; then
+              c_major=1
+              c_minor=0
+            else
+              IFS=. read -r _ c_major c_minor <<< "$latest_calver"
+              case "$RELEASE_TYPE" in
+                major) c_major=$((c_major + 1)); c_minor=0 ;;
+                minor) c_minor=$((c_minor + 1)) ;;
+              esac
             fi
-
-            # Guard against a major release producing anything other
-            # than the next major component followed by .0.
-            if [ "$RELEASE_TYPE" = "major" ]; then
-              expected_major=$((old_c_major + 1))
-
-              if [ "$c_major" -ne "$expected_major" ]; then
-                echo "::error::A major release did not increment the CalVer major component correctly."
-                exit 1
-              fi
-
-              if [ "$c_minor" -ne 0 ]; then
-                echo "::error::A major release did not reset the CalVer minor component to zero."
-                exit 1
-              fi
-            fi
+            calver="${year}.${c_major}.${c_minor}"
+            reuse=false
           fi
 
-          calver="${year}.${c_major}.${c_minor}"
-
-          # Prevent overwriting existing version tags.
-          if git rev-parse "$semver" >/dev/null 2>&1; then
-            echo "::error::SemVer tag already exists: $semver"
-            exit 1
-          fi
-
-          if git rev-parse "$calver" >/dev/null 2>&1; then
-            echo "::error::CalVer tag already exists: $calver"
-            exit 1
-          fi
-
-          echo "semver=$semver" >> "$GITHUB_OUTPUT"
-          echo "calver=$calver" >> "$GITHUB_OUTPUT"
-
-          echo ""
-          echo "Release calculation:"
-          echo "  Type:   $RELEASE_TYPE"
-          echo "  SemVer: $latest_semver -> $semver"
-          echo "  CalVer: ${latest_calver:-none} -> $calver"
+          previous_calver=$(git tag -l '[0-9][0-9][0-9][0-9].*.*' \
+            | grep -v -x "$calver" | sort -V | tail -n1 || true)
+          {
+            echo "semver=$semver"
+            echo "calver=$calver"
+            echo "previous_calver=$previous_calver"
+            echo "reuse=$reuse"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ vars.PYTHON_VERSION || '3.11' }}
 
-      - name: Bump roman-dataref-test version and pin requirements
-        shell: bash
+      - name: Prepare versioned data-reference package
+        if: steps.version.outputs.reuse != 'true'
         env:
-          CALVER: ${{ steps.ver.outputs.calver }}
+          CALVER: ${{ steps.version.outputs.calver }}
+          SEMVER: ${{ steps.version.outputs.semver }}
+        shell: bash
         run: |
           set -euo pipefail
-
-          sed -i \
-            "s/^version = .*/version = \"$CALVER\"/" \
-            pyproject.toml
-
-          while IFS= read -r -d '' requirements_file; do
-            sed -i \
-              "s|roman-dataref-test[^[:space:]]*|roman-dataref-test==$CALVER|g" \
-              "$requirements_file"
-          done < <(
-            find notebooks \
-              -type f \
-              -name requirements.txt \
-              -print0
-          )
-
-          echo "Updated pyproject.toml to version $CALVER"
-          echo ""
-          echo "Updated requirements references:"
-
-          grep -R \
-            --include='requirements.txt' \
-            -n \
-            "roman-dataref-test" \
-            notebooks \
-            || true
-
-      - name: Commit version bump
-        shell: bash
-        env:
-          CALVER: ${{ steps.ver.outputs.calver }}
-        run: |
-          set -euo pipefail
-
-          git config user.name "github-actions[bot]"
-          git config user.email \
-            "41898282+github-actions[bot]@users.noreply.github.com"
-
+          sed -i "s/^version = .*/version = \"$CALVER\"/" pyproject.toml
+          while IFS= read -r -d '' file; do
+            if grep -q 'roman-dataref-test' "$file"; then
+              sed -i "s|roman-dataref-test[^[:space:]]*|roman-dataref-test==$CALVER|g" "$file"
+            fi
+          done < <(find notebooks -type f -name requirements.txt -print0)
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add pyproject.toml notebooks
-
-          if git diff --cached --quiet; then
-            current_version="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -n1)"
-            echo "::error::The version bump did not produce any file changes."
-            echo "::error::Computed CALVER: ${CALVER}"
-            echo "::error::Current pyproject.toml version: ${current_version:-unknown}"
-            echo "::error::If this is the first CalVer release for a new package name, create and push a bootstrap tag matching the current version (for example: git tag ${CALVER} && git push origin ${CALVER}), then rerun with release_type=minor."
-            exit 1
-          fi
-
-          git commit \
-            -m "Bump roman-dataref-test to ${CALVER}"
-
-      - name: Push version commit
-        shell: bash
-        run: |
-          set -euo pipefail
-          git push origin HEAD:main
+          git commit -m "Release ${CALVER} (${SEMVER})"
 
       - name: Build package
         shell: bash
         run: |
           set -euo pipefail
-
-          python -m pip install --upgrade pip build
+          python -m pip install --upgrade build
           python -m build
 
-          echo ""
-          echo "Built distribution files:"
-          ls -lah dist/
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: roman-dataref-${{ steps.version.outputs.calver }}
+          path: dist/
+          if-no-files-found: error
 
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     password: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Publish package step disabled
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "PyPI publish is temporarily disabled in this workflow."
-
-      - name: Create and push tags
-        shell: bash
+      - name: Publish commit and tags atomically
+        id: publish
         env:
-          SEMVER: ${{ steps.ver.outputs.semver }}
-          CALVER: ${{ steps.ver.outputs.calver }}
+          CALVER: ${{ steps.version.outputs.calver }}
+          SEMVER: ${{ steps.version.outputs.semver }}
+          REUSE: ${{ steps.version.outputs.reuse }}
+        shell: bash
         run: |
           set -euo pipefail
+          if [[ "$REUSE" != "true" ]]; then
+            git tag "$SEMVER"
+            git tag "$CALVER"
+            git push --atomic origin \
+              HEAD:refs/heads/main \
+              "refs/tags/$SEMVER" \
+              "refs/tags/$CALVER"
+          fi
+          echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-          git config user.name "github-actions[bot]"
-          git config user.email \
-            "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git tag "$SEMVER"
-          git tag "$CALVER"
-
-          git push origin \
-            "refs/tags/$SEMVER" \
-            "refs/tags/$CALVER"
-
-      - name: Create GitHub release
-        shell: bash
+      - name: Create or recover GitHub release
+        id: metadata
         env:
           GH_TOKEN: ${{ github.token }}
-          CALVER: ${{ steps.ver.outputs.calver }}
+          CALVER: ${{ steps.version.outputs.calver }}
+          PREVIOUS_CALVER: ${{ steps.version.outputs.previous_calver }}
+        shell: bash
         run: |
           set -euo pipefail
-
-          display_name="${RELEASE_DISPLAY_NAME:-}"
-
-          if [ -z "$display_name" ]; then
-            raw="${GITHUB_REPOSITORY##*/}"
-
-            display_name="$(
-              printf '%s' "$raw" \
-                | tr '-_' '  ' \
-                | awk '{
-                    for (i = 1; i <= NF; i++) {
-                      $i = toupper(substr($i, 1, 1)) substr($i, 2)
-                    }
-                  } 1'
-            )"
+          if ! gh release view "$CALVER" >/dev/null 2>&1; then
+            args=("$CALVER" --title "${RELEASE_DISPLAY_NAME} - ${CALVER}" \
+              --generate-notes --verify-tag --latest)
+            if [[ -n "$PREVIOUS_CALVER" ]]; then
+              args+=(--notes-start-tag "$PREVIOUS_CALVER")
+            fi
+            gh release create "${args[@]}"
           fi
+          echo "release_url=https://github.com/${GITHUB_REPOSITORY}/releases/tag/${CALVER}" \
+            >> "$GITHUB_OUTPUT"
 
-          gh release create "$CALVER" \
-            --title "${display_name} - ${CALVER}" \
-            --generate-notes \
-            --verify-tag \
-            --latest
+  publish-package:
+    needs: release
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: roman-dataref-${{ needs.release.outputs.calver }}
+          path: dist
+      - name: Publish versioned data-reference package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
-#      - name: Summary
-#        shell: bash
-#        env:
-#          RELEASE_TYPE: ${{ inputs.release_type }}
-#          CALVER: ${{ steps.ver.outputs.calver }}
-#          SEMVER: ${{ steps.ver.outputs.semver }}
-#        run: |
-#          {
-#            echo "### Release cut :rocket:"
-#            echo ""
-#            echo "| | |"
-#            echo "|---|---|"
-#            echo "| Type | \`$RELEASE_TYPE\` |"
-#            echo "| CalVer product version | \`$CALVER\` |"
-#            echo "| SemVer internal version | \`$SEMVER\` |"
-#            echo "| Commit | \`$GITHUB_SHA\` |"
-#          } >> "$GITHUB_STEP_SUMMARY"
+  rrn:
+    needs:
+      - release
+      - publish-package
+    if: vars.TRIGGER_RRN_IMAGE_BUILD == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build and deploy Roman Research Nexus image
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ secrets.RRN_ACTIONS_TOKEN }}
+          RRN_SOURCE_REPOSITORY: ${{ github.repository }}
+          RRN_SOURCE_REF: ${{ needs.release.outputs.calver }}
+          RRN_SOURCE_VERSION: ${{ needs.release.outputs.calver }}
+          RRN_VERSION_KIND: calver
+          RRN_TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+          RRN_DELIVERY_MODE: image
+          RRN_SOURCE_SHA: ${{ needs.release.outputs.source_sha }}
+          RRN_RELEASE_URL: ${{ needs.release.outputs.release_url }}
+          RRN_CORRELATION_ID: ${{ github.run_id }}-${{ github.run_attempt }}-calver
+        shell: bash
+        run: bash .github/scripts/dispatch_rrn_build.sh
+
+      - name: Summary
+        env:
+          RRN_RUN_URL: ${{ steps.dispatch.outputs.rrn_run_url }}
+        shell: bash
+        run: |
+          {
+            echo "### CalVer release"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| CalVer | \`${{ needs.release.outputs.calver }}\` |"
+            echo "| SemVer | \`${{ needs.release.outputs.semver }}\` |"
+            echo "| Target | \`${{ inputs.target_environment }}\` |"
+            echo "| RRN run | ${RRN_RUN_URL} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,8 +1,5 @@
 name: Auto patch bump
-
-# Tags every merge/push to main with the next SemVer patch (vX.Y.PATCH+1).
-# These are plain git tags only — no GitHub Release is attached, so the
-# "Cut release" workflow can later generate notes spanning all of them.
+run-name: SemVer test release for ${{ github.sha }}
 
 on:
   push:
@@ -11,7 +8,9 @@ on:
 permissions:
   contents: write
 
-# Serialize with the release workflow so two runs never race on tags.
+env:
+  RELEASE_DISPLAY_NAME: Notebook CI Testing
+
 concurrency:
   group: version-tagging
   cancel-in-progress: false
@@ -19,35 +18,122 @@ concurrency:
 jobs:
   patch:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.next }}
+      previous: ${{ steps.version.outputs.previous }}
+      delivery_mode: ${{ steps.classify.outputs.delivery_mode }}
+      delivery_reason: ${{ steps.classify.outputs.reason }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
-          fetch-depth: 0      # full history + all tags must be visible
+          fetch-depth: 0
           fetch-tags: true
 
-      - name: Compute next patch version
-        id: ver
+      - name: Compute or recover patch version
+        id: version
         shell: bash
         run: |
           set -euo pipefail
-          # Highest existing SemVer tag (v-prefixed only; CalVer tags are ignored).
-          latest="$(git tag -l 'v*.*.*' | sort -V | tail -n1)"
-          [ -z "$latest" ] && latest="v0.0.0"
+          git fetch origin --force --tags
+          exact=$(git tag --points-at HEAD \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)
+          if [[ -n "$exact" ]]; then
+            next=$exact
+            tag_needed=false
+            previous=$(git tag -l 'v*.*.*' | grep -v -x "$next" \
+              | sort -V | tail -n1 || true)
+          else
+            previous=$(git tag -l 'v*.*.*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)
+            previous=${previous:-v0.0.0}
+            IFS=. read -r major minor patch <<< "${previous#v}"
+            next="v${major}.${minor}.$((patch + 1))"
+            tag_needed=true
+          fi
+          {
+            echo "next=$next"
+            echo "previous=$previous"
+            echo "tag_needed=$tag_needed"
+          } >> "$GITHUB_OUTPUT"
 
-          core="${latest#v}"
-          IFS='.' read -r major minor patch <<< "$core"
-          patch=$((patch + 1))
-          next="v${major}.${minor}.${patch}"
-
-          echo "next=$next" >> "$GITHUB_OUTPUT"
-          echo "Bumping ${latest} -> ${next}"
-
-      - name: Tag the merge
+      - name: Publish SemVer tag
+        if: steps.version.outputs.tag_needed == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.next }}
         shell: bash
         run: |
           set -euo pipefail
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "${{ steps.ver.outputs.next }}"
-          git push origin "${{ steps.ver.outputs.next }}"
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git tag "$VERSION"
+          git push origin "refs/tags/$VERSION"
+
+      - name: Create or recover SemVer test release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.next }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! gh release view "$VERSION" >/dev/null 2>&1; then
+            gh release create "$VERSION" \
+              --title "${RELEASE_DISPLAY_NAME} - ${VERSION} test" \
+              --generate-notes --verify-tag --prerelease --latest=false
+          fi
+
+      - name: Classify RRN delivery mode
+        id: classify
+        env:
+          PREVIOUS: ${{ steps.version.outputs.previous }}
+          CURRENT: ${{ steps.version.outputs.next }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$PREVIOUS" || "$PREVIOUS" == "v0.0.0" ]]; then
+            {
+              echo "delivery_mode=image"
+              echo "reason=No previous SemVer release exists"
+            } >> "$GITHUB_OUTPUT"
+          else
+            bash .github/scripts/classify_rrn_delivery.sh "$PREVIOUS" "$CURRENT" \
+              >> "$GITHUB_OUTPUT"
+          fi
+
+  rrn:
+    needs: patch
+    if: vars.TRIGGER_RRN_TEST_IMAGE_BUILD == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build and deploy RRN test image
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ secrets.RRN_ACTIONS_TOKEN }}
+          RRN_SOURCE_REPOSITORY: ${{ github.repository }}
+          RRN_SOURCE_REF: ${{ needs.patch.outputs.version }}
+          RRN_SOURCE_VERSION: ${{ needs.patch.outputs.version }}
+          RRN_VERSION_KIND: semver
+          RRN_TARGET_ENVIRONMENT: test
+          RRN_DELIVERY_MODE: ${{ needs.patch.outputs.delivery_mode }}
+          RRN_SOURCE_SHA: ${{ github.sha }}
+          RRN_RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ needs.patch.outputs.version }}
+          RRN_CORRELATION_ID: ${{ github.run_id }}-${{ github.run_attempt }}-semver
+        shell: bash
+        run: bash .github/scripts/dispatch_rrn_build.sh
+
+      - name: Summary
+        env:
+          RRN_RUN_URL: ${{ steps.dispatch.outputs.rrn_run_url }}
+        shell: bash
+        run: |
+          {
+            echo "### SemVer test release"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| SemVer | \`${{ needs.patch.outputs.version }}\` |"
+            echo "| Delivery recommendation | \`${{ needs.patch.outputs.delivery_mode }}\` |"
+            echo "| Reason | ${{ needs.patch.outputs.delivery_reason }} |"
+            echo "| RRN run | ${RRN_RUN_URL} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/notebooks/aperture_photometry/requirements.txt
+++ b/notebooks/aperture_photometry/requirements.txt
@@ -12,3 +12,4 @@ photutils>=2.2.0
 matplotlib>=3.10.0
 numpy>=2.4.4
 stpsf>=2.1.0
+roman-dataref-test==2026.1.1

--- a/notebooks/pandeia/requirements.txt
+++ b/notebooks/pandeia/requirements.txt
@@ -5,3 +5,4 @@ scipy>=1.17.1
 healpy>=1.18.1
 matplotlib>=3.10.0
 numpy>=2.4.4
+roman-dataref-test==2026.1.1

--- a/notebooks/romanisim/requirements.txt
+++ b/notebooks/romanisim/requirements.txt
@@ -14,3 +14,4 @@ numpy>=2.4.4
 s3fs>=2025.5.1
 dask[complete]
 stpsf>=2.1.0
+roman-dataref-test==2026.1.1

--- a/notebooks/stips/requirements.txt
+++ b/notebooks/stips/requirements.txt
@@ -3,3 +3,4 @@ astropy>=7.2.0
 matplotlib>=3.10.0
 esutil>=0.6.16 # --no-cache-dir option recommended on pip install
 stsynphot>=1.5.1
+roman-dataref-test==2026.1.1

--- a/notebooks/stpsf/requirements.txt
+++ b/notebooks/stpsf/requirements.txt
@@ -3,3 +3,4 @@ stpsf>=2.1.0
 matplotlib>=3.10.0
 numpy>=2.4.4
 stsynphot>=1.5.1
+roman-dataref-test==2026.1.1

--- a/notebooks/synphot/requirements.txt
+++ b/notebooks/synphot/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.32.5
 synphot>=1.5.0
 stsynphot>=1.5.1
 stpsf>=2.1.0
+roman-dataref-test==2026.1.1

--- a/notebooks/time_domain_simulations/requirements.txt
+++ b/notebooks/time_domain_simulations/requirements.txt
@@ -14,3 +14,4 @@ pysiaf>=0.24.1
 sncosmo>=2.12.1
 astrocut>=1.2.0
 stpsf>=2.1.0
+roman-dataref-test==2026.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ py-modules = ["notebook_data_dependencies"]
 
 [tool.setuptools.package-dir]
 "" = "shared"
+
+[tool.setuptools.data-files]
+"share/roman-dataref-test" = ["refdata_dependencies.yaml"]

--- a/shared/notebook_data_dependencies.py
+++ b/shared/notebook_data_dependencies.py
@@ -1,20 +1,59 @@
 import os
+from pathlib import Path
 import requests
+import sysconfig
 import tarfile
 import tempfile
 import yaml
-def _load_yaml(dependencies):
+
+
+_MANIFEST_NAME = 'refdata_dependencies.yaml'
+_MANIFEST_ENV_VAR = 'ROMAN_REFDATA_MANIFEST'
+
+
+def _resolve_dependencies(dependencies=None):
+    """Resolve the manifest shipped with this checkout or installed wheel."""
+    if dependencies:
+        return str(dependencies)
+
+    override = os.environ.get(_MANIFEST_ENV_VAR)
+    if override:
+        return override
+
+    module_path = Path(__file__).resolve()
+    candidates = [
+        module_path.parent.parent / _MANIFEST_NAME,
+        Path.cwd() / _MANIFEST_NAME,
+        Path(sysconfig.get_path('data'))
+        / 'share'
+        / 'roman-dataref-test'
+        / _MANIFEST_NAME,
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+
+    checked = '\n'.join(f'  - {candidate}' for candidate in candidates)
+    raise FileNotFoundError(
+        f'Could not locate {_MANIFEST_NAME}.\nChecked:\n{checked}\n'
+        f'Set {_MANIFEST_ENV_VAR} to an explicit local path or URL.'
+    )
+
+
+def _load_yaml(dependencies=None):
     """Load a YAML file from a local path or URL."""
+    dependencies = _resolve_dependencies(dependencies)
     if os.path.exists(dependencies):
-        with open(dependencies, 'r') as f:
+        with open(dependencies, 'r', encoding='utf-8') as f:
             return yaml.safe_load(f)
-    else:
+    if dependencies.startswith(('http://', 'https://')):
         req = requests.get(dependencies, allow_redirects=True, timeout=(10, 60))
         req.raise_for_status()
         return yaml.safe_load(req.content)
+    raise FileNotFoundError(f'Dependency manifest does not exist: {dependencies}')
 
 
-def install_files(dependencies='https://raw.githubusercontent.com/spacetelescope/roman_notebooks/main/refdata_dependencies.yaml',
+def install_files(dependencies=None,
                      verbose=True, packages=None):
     """
     PURPOSE
@@ -31,11 +70,9 @@ def install_files(dependencies='https://raw.githubusercontent.com/spacetelescope
     
     INPUTS
     ------
-    dependencies (str): A URL or local path to the YAML definition file for the data 
-    dependencies. The code will first check for the existence of the file locally, and 
-    if it does not exist then it will assume the input is a URL. The default is the URL 
-    of the file on the roman_notebooks GitHub repository. The YAML file should have the 
-    following format:
+    dependencies (str): A URL or local path to the YAML definition file for the data
+    dependencies. By default, the helper uses the manifest from the repository checkout
+    or the installed, versioned package. The YAML file should have the following format:
             
         package_name:  # Name of the package
             version:  # Package version number for documentation
@@ -134,7 +171,7 @@ def install_files(dependencies='https://raw.githubusercontent.com/spacetelescope
     return result
 
 def setup_env(result,
-              dependencies='https://raw.githubusercontent.com/spacetelescope/roman_notebooks/main/refdata_dependencies.yaml',
+              dependencies=None,
               verbose=True):
     # Apply install_files results (existing behaviour)
     print('Reference data paths set to:')
@@ -157,6 +194,6 @@ def setup_env(result,
             print(f"\t{key} = {os.environ[key]} (pre-set, not overwritten)")
 
 
-if __name__ == 'main':
+if __name__ == '__main__':
 
     install_files()


### PR DESCRIPTION
## Summary

Uses `notebook-ci-testing` as the proving ground for the Roman Research Nexus delivery flow. Once the flow is accepted, the release changes can move to `spacetelescope/roman_notebooks`.

- Creates a SemVer prerelease for every push to `main`, classifies the change as `spec` or `image`, dispatches test delivery, and waits for the downstream result.
- Keeps CalVer as the controlled release path, requires it to run from the current `main`, and dispatches an image delivery to the selected test or ops target.
- Separates the version kind from the target environment in every downstream request.
- Adds correlation IDs so upstream runs can find and wait for the exact SPI run.
- Builds a versioned `roman-dataref-test` package containing the helper and dependency manifest.
- Pins that package in every notebook requirements file that imports the helper.
- Publishes the package with PyPI trusted publishing and updates the pin during each CalVer release.

## Safety and recovery

- Ops delivery is rejected from this testing repository. It becomes available only after migration to `spacetelescope/roman_notebooks`.
- Release commits and SemVer and CalVer tags are pushed atomically.
- Reruns recover existing tags and releases instead of incrementing versions again.
- Package publishing uses `skip-existing` so a partial release can be retried.
- Any file the classifier does not recognize is treated as image-affecting.

## Configuration

Set these repository variables when the corresponding path is ready to test:

- `TRIGGER_RRN_TEST_IMAGE_BUILD=true`
- `TRIGGER_RRN_IMAGE_BUILD=true`

Add `RRN_ACTIONS_TOKEN` with permission to run the RRN workflow in `spacetelescope/science-platform-images`.

Create the `pypi` environment and configure its trusted publisher before testing a CalVer release.

## Validation

- `actionlint` passes for both workflows.
- Both shell helpers pass Bash syntax checks.
- The package wheel contains the helper and YAML manifest.
- An installed wheel resolves its bundled manifest outside the repository.
- All seven notebooks that import the helper have the package pin.
- `git diff --check` passes.